### PR TITLE
Fix slug handling for recurring events

### DIFF
--- a/models/Event.js
+++ b/models/Event.js
@@ -3,6 +3,7 @@ const environment = process.env.NODE_ENV || 'development';
 const config = require('../knexfile')[environment];
 const knex = require('knex')(config);
 const { v4: uuidv4 } = require('uuid');
+const slugify = require('../utils/slugify');
 
  // Adjust the path as necessary for your project structure
 
@@ -12,11 +13,13 @@ const createEvent = async (eventData) => {
 
 const createRecurringEvents = async (baseEventData, recurrenceDates) => {
   const recurring_group_id = uuidv4();
+  const baseSlug = baseEventData.slug || slugify(baseEventData.title);
 
   const eventsToInsert = recurrenceDates.map((recurrenceDate) => ({
     ...baseEventData,
     date: recurrenceDate,
     recurring_group_id,
+    slug: `${baseSlug}-${uuidv4()}`,
   }));
 
   return knex('events').insert(eventsToInsert).returning('*');

--- a/routes/eventRouter.js
+++ b/routes/eventRouter.js
@@ -63,6 +63,7 @@ eventRouter.post('/submit', upload.single('poster'), async (req, res) => {
       start_time,
       end_time,
       recurrenceDates,
+      slug: providedSlug,
     } = req.body;
 
     // poster URL (or null)
@@ -74,7 +75,7 @@ eventRouter.post('/submit', upload.single('poster'), async (req, res) => {
       ticket_price = parseFloat(ticket_price.replace(/[^\d.]/g, ''));
     }
     if (isNaN(ticket_price)) ticket_price = null;
-    const slug =  await generateUniqueSlug(title);
+    const slug = providedSlug || await generateUniqueSlug(title);
 
     const baseEventData = {
       user_id,
@@ -159,6 +160,7 @@ eventRouter.post('/submit-multiple', upload.array('posters'), async (req, res) =
         end_time,
         ticket_price,
         recurrenceDates,
+        slug: providedSlug,
       } = event;
 
       const posterUrl = posterFile ? posterFile.location : null;
@@ -168,7 +170,7 @@ eventRouter.post('/submit-multiple', upload.array('posters'), async (req, res) =
       }
       if (isNaN(ticket_price)) ticket_price = null;
 
-      const slug = await generateUniqueSlug(title);
+      const slug = providedSlug || await generateUniqueSlug(title);
 
       const baseEventData = {
         user_id,


### PR DESCRIPTION
## Summary
- generate unique slug for each recurring event
- use slug from request if provided when submitting events

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684cd8b8e600832c9aa256867d5fcbd9