### PR TITLE
Add dayjs trial helper

### DIFF
--- a/models/Artist.js
+++ b/models/Artist.js
@@ -1,6 +1,7 @@
 const environment = process.env.NODE_ENV || 'development';
 const config = require('../knexfile')[environment];
 const knex = require('knex')(config);
+const isInTrial = require('../utils/isInTrial');
 
 const Artist = {
   findBySlug: async (slug) => {
@@ -33,9 +34,7 @@ const Artist = {
       .orderBy('date');
 
       const isTrialExpired =
-      artist.trial_ends_at !== null
-        ? new Date() > new Date(artist.trial_ends_at)
-        : false;
+        artist.trial_ends_at !== null ? !isInTrial(artist.trial_ends_at) : false;
     
 
     return {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "redis": "^4.7.0",
     "serverless-http": "^3.2.0",
     "sqlite3": "^5.1.7",
-    "stripe": "^18.2.0"
+    "stripe": "^18.2.0",
+    "dayjs": "^1.11.9"
   }
 }

--- a/routes/authRouter.js
+++ b/routes/authRouter.js
@@ -2,6 +2,7 @@ const express = require('express');
 const crypto = require('crypto'); // Node.js built-in module
 const bcrypt = require('bcryptjs');
 const passport = require('passport');
+const isInTrial = require('../utils/isInTrial');
 const { S3Client } = require('@aws-sdk/client-s3');
 const { fromEnv } = require('@aws-sdk/credential-provider-env');
 const multer = require('multer');
@@ -187,11 +188,12 @@ authRouter.get('/session', (req, res) => {
         email: req.user.email,
         is_admin: req.user.is_admin,
         is_pro: req.user.is_pro,
-        trial_ends_at: req.user.trial_ends_at, 
+        trial_active: isInTrial(req.user.trial_ends_at),
+        trial_ends_at: req.user.trial_ends_at,
         displayName: req.user.display_name,
         top_music_genres: req.user.top_music_genres,
         user_description: req.user.user_description
-      } 
+      }
     });
   } else {
     return res.json({ isLoggedIn: false, user: null });
@@ -232,15 +234,16 @@ authRouter.post('/login', (req, res, next) => {
         await updateUserLoginStatus(user.id, true);
         res.json({
           message: 'Logged in successfully',
-          user: { 
-            id: user.id, 
-            first_name: user.first_name, 
-            last_name: user.last_name, 
-            email: user.email, 
-            is_logged_in: user.is_logged_in, 
+          user: {
+            id: user.id,
+            first_name: user.first_name,
+            last_name: user.last_name,
+            email: user.email,
+            is_logged_in: user.is_logged_in,
             is_admin: user.is_admin,
             is_pro: user.is_pro,
-            trial_ends_at: user.trial_ends_at, // ✅ add this
+            trial_active: isInTrial(user.trial_ends_at),
+            trial_ends_at: user.trial_ends_at,
             top_music_genres: user.top_music_genres,
             displayName: user.display_name,
             user_description: user.user_description,

--- a/utils/isInTrial.js
+++ b/utils/isInTrial.js
@@ -1,0 +1,3 @@
+const dayjs = require('dayjs');
+
+module.exports = trialEnd => dayjs().isBefore(dayjs(trialEnd));


### PR DESCRIPTION
## Summary
- add `utils/isInTrial.js` to centralize trial checks
- use `isInTrial` in artist model and auth routes
- send `trial_active` flag in login/session responses
- include `dayjs` dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ce061b9e4832c9e3e5d7df9490358