### PR TITLE
Add trial checks to artist and event routes

### DIFF
--- a/routes/artistRouter.js
+++ b/routes/artistRouter.js
@@ -8,6 +8,7 @@ const multerS3 = require('multer-s3');
 const { S3Client, DeleteObjectCommand } = require('@aws-sdk/client-s3');
 const { fromEnv } = require('@aws-sdk/credential-provider-env');
 const { v4: uuidv4 } = require('uuid');
+const isInTrial = require('../utils/isInTrial');
 const artistRouter = express.Router();
 const Artist = require('../models/Artist');
 
@@ -143,6 +144,10 @@ artistRouter.put('/:slug', upload.fields([
   // Ownership check
   if (artist.user_id !== req.user.id && !req.user.is_admin) {
     return res.status(403).json({ message: 'Not authorized' });
+  }
+
+  if (!isInTrial(req.user.trial_ends_at)) {
+    return res.status(403).json({ message: 'Trial expired. Upgrade to edit your profile.' });
   }
 
   try {

--- a/routes/eventRouter.js
+++ b/routes/eventRouter.js
@@ -9,6 +9,7 @@ const { findUserById } = require("../models/User");   // add this line
 const { DeleteObjectCommand } = require('@aws-sdk/client-s3');
 const slugify = require("../utils/slugify")
 const generateUniqueSlug = require('../utils/generateUniqueSlug');
+const isInTrial = require('../utils/isInTrial');
 
 const {
   deleteEvent,
@@ -45,6 +46,10 @@ const eventRouter = express.Router();
 eventRouter.post('/submit', upload.single('poster'), async (req, res) => {
   if (!req.isAuthenticated?.()) {
     return res.status(401).json({ message: 'Not authenticated' });
+  }
+
+  if (!isInTrial(req.user.trial_ends_at)) {
+    return res.status(403).json({ message: 'Trial expired. Upgrade to submit events.' });
   }
 
   try {
@@ -129,6 +134,10 @@ eventRouter.post('/submit', upload.single('poster'), async (req, res) => {
 eventRouter.post('/submit-multiple', upload.array('posters'), async (req, res) => {
   if (!req.isAuthenticated?.()) {
     return res.status(401).json({ message: 'Not authenticated' });
+  }
+
+  if (!isInTrial(req.user.trial_ends_at)) {
+    return res.status(403).json({ message: 'Trial expired. Upgrade to submit events.' });
   }
 
   try {

--- a/utils/isInTrial.js
+++ b/utils/isInTrial.js
@@ -1,0 +1,5 @@
+function isInTrial(trialEndsAt) {
+  if (!trialEndsAt) return true;
+  return new Date() <= new Date(trialEndsAt);
+}
+module.exports = isInTrial;


### PR DESCRIPTION
## Summary
- enforce trial check for artist profile edits and event creation
- create reusable `isInTrial` util

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ce0633984832c91805574016b9824