### PR TITLE
Implement profile restore endpoint

### DIFF
--- a/models/Artist.js
+++ b/models/Artist.js
@@ -65,6 +65,14 @@ const Artist = {
       .update(updates)
       .returning('*');
     return updated;
+  },
+
+  restore: async (id) => {
+    const [restored] = await knex('artists')
+      .where({ id })
+      .update({ deleted_at: null })
+      .returning('*');
+    return restored;
   }
 };
 

--- a/routes/artistRouter.js
+++ b/routes/artistRouter.js
@@ -211,6 +211,24 @@ artistRouter.delete('/:slug', async (req, res) => {
   }
 });
 
+// PUT /api/artists/:id/restore — restore soft-deleted artist profile
+artistRouter.put('/:id/restore', async (req, res) => {
+  if (!req.isAuthenticated?.()) return res.status(401).json({ message: 'Unauthorized' });
+
+  const { id } = req.params;
+
+  try {
+    const restored = await Artist.restore(id);
+    if (!restored) {
+      return res.status(404).json({ message: 'Artist not found' });
+    }
+    res.json(restored);
+  } catch (err) {
+    console.error('Restore artist error:', err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
 
 
 module.exports = artistRouter;


### PR DESCRIPTION
## Summary
- extend `Artist` model with `restore` method
- allow restoring soft-deleted artist profiles via `PUT /api/artists/:id/restore`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ced3d834c832cbd69bb798568d4fd