### PR TITLE
Handle duplicate artist slug

### DIFF
--- a/models/Artist.js
+++ b/models/Artist.js
@@ -11,6 +11,14 @@ const Artist = {
       .first();
   },
 
+  // Check if a slug exists regardless of soft deletion
+  slugExists: async (slug) => {
+    const existing = await knex('artists')
+      .where({ slug })
+      .first();
+    return !!existing;
+  },
+
   findAllPublic: async () => {
     return knex('artists')
       .select('display_name', 'slug', 'profile_image', 'genres', 'bio')

--- a/routes/artistRouter.js
+++ b/routes/artistRouter.js
@@ -68,8 +68,10 @@ artistRouter.post('/', upload.fields([
   const slug = customSlug ? customSlug.toLowerCase().replace(/\s+/g, '-') : display_name.toLowerCase().replace(/\s+/g, '-');
 
   try {
-    const exists = await Artist.findBySlug(slug);
-    if (exists) return res.status(409).json({ message: 'Slug is taken' });
+    const exists = await Artist.slugExists(slug);
+    if (exists) {
+      return res.status(409).json({ message: 'An artist with that slug already exists' });
+    }
 
     const files = req.files;
 
@@ -106,6 +108,9 @@ if (!existingUser.trial_ends_at) {
 }
     res.status(201).json(newArtist);
   } catch (err) {
+    if (err.code === '23505') {
+      return res.status(409).json({ message: 'An artist with that slug already exists' });
+    }
     console.error('Create artist error:', err);
     res.status(500).json({ message: 'Server error' });
   }


### PR DESCRIPTION
## Summary
- check slug existence across all artists
- return conflict when slug already exists
- catch duplicate key errors gracefully

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d0236ecb8832c806dca43d1fb1747