### PR TITLE
Add admin middleware

### DIFF
--- a/routes/artistRouter.js
+++ b/routes/artistRouter.js
@@ -9,6 +9,7 @@ const { S3Client, DeleteObjectCommand } = require('@aws-sdk/client-s3');
 const { fromEnv } = require('@aws-sdk/credential-provider-env');
 const { v4: uuidv4 } = require('uuid');
 const isInTrial = require('../utils/isInTrial');
+const isAdmin = require('../utils/isAdmin');
 const artistRouter = express.Router();
 const Artist = require('../models/Artist');
 

--- a/routes/eventRouter.js
+++ b/routes/eventRouter.js
@@ -9,6 +9,7 @@ const { findUserById } = require("../models/User");   // add this line
 const { DeleteObjectCommand } = require('@aws-sdk/client-s3');
 const slugify = require("../utils/slugify")
 const generateUniqueSlug = require('../utils/generateUniqueSlug');
+const isAdmin = require('../utils/isAdmin');
 
 const {
   deleteEvent,
@@ -231,7 +232,7 @@ eventRouter.post('/submit-multiple', upload.array('posters'), async (req, res) =
 /**
  * Fetch events pending review
  */
-eventRouter.get('/review', async (req, res) => {
+eventRouter.get('/review', isAdmin, async (req, res) => {
   try {
     const events = await getEventsForReview();
     res.json(events);
@@ -244,7 +245,7 @@ eventRouter.get('/review', async (req, res) => {
 /**
  * Update event status (approve/deny)
  */
-eventRouter.put('/review/:eventId', async (req, res) => {
+eventRouter.put('/review/:eventId', isAdmin, async (req, res) => {
   try {
     const { eventId }  = req.params;
     const { isApproved } = req.body;

--- a/utils/isAdmin.js
+++ b/utils/isAdmin.js
@@ -1,0 +1,8 @@
+function isAdmin(req, res, next) {
+  if (!req.isAuthenticated?.() || !req.user?.is_admin) {
+    return res.status(403).json({ message: 'Admin access required' });
+  }
+  next();
+}
+
+module.exports = isAdmin;


### PR DESCRIPTION
## Summary
- add `isAdmin` middleware to check admin privileges
- secure event review endpoints with admin middleware
- make `artistRouter` import the new middleware

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d12c46710832c9d5aed43ad738e5b