### PR TITLE
Fix Stripe webhook parser setup

### DIFF
--- a/routes/stripe.js
+++ b/routes/stripe.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const Stripe = require('stripe');
 const router = express.Router();
-const bodyParser = require('body-parser');
 const knex = require('../db/knex');
 
 const stripe = Stripe(process.env.STRIPE_SECRET_KEY);
@@ -104,7 +103,7 @@ router.post('/create-checkout-session', async (req, res) => {
 
 
 // Stripe webhook route
-router.post('/webhook', bodyParser.raw({ type: 'application/json' }), async (req, res) => {
+router.post('/webhook', async (req, res) => {
   const sig = req.headers['stripe-signature'];
   let event;
 


### PR DESCRIPTION
## Summary
- remove unused `body-parser` import from `routes/stripe.js`
- simplify webhook route definition
- keep raw parser in `app.js` before JSON parser

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6861f7a37914832c84e283b78af902ed